### PR TITLE
chore: .github/pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,3 +18,10 @@ All these are optional depending on the size and context of the work being done.
 
 * Provide the paths at which the UI have changed and instructions on how to navigate to the areas affected by the PR
 * Explain how it was before and how these changes affect the UI/system, what should people notice after the changes have been introduced
+
+## Key decisions
+
+* Important decisions with ramifications on future work
+* Tradeoffs
+* Heads up for new reusable components
+


### PR DESCRIPTION
## Purpose

This PR will provide a template for all the projects we'll spin up from this repo.

## Approach

Dakota gave me an explanation of the template in GLU:

https://github.com/Labrys-Group/glue-monorepo/blob/dev/.github/pull_request_template.md

I'm adapting it to be more generic and to work well with agent generation.

## QA

This is testing in the GLU template, but they mean QA. I'm not sure this is what we should do, it's a _code review_, and we should have automated testing, do we want devs to QA? I guess if they want to, and it's good context to provide.
