### PR TITLE
Prevent sync-upstream workflow from running in template-based repos

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   sync:
+    # Only run this workflow in the original repository, not in repos created from template
+    if: github.repository == 'Labrys-Group/create-t3-turbo'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Add repository check to only run the upstream sync workflow in the original Labrys-Group/create-t3-turbo repository. This prevents the workflow from executing in any repos created from this template, avoiding unnecessary workflow runs and potential confusion for users.

## Purpose

* https://labrys.atlassian.net/browse/XXX-NNNN (or whatever the source of the PR's creation is)
* Outline what the PR is addressing in a brief sentence form
* Explain how it relates to the Jira card, if it completes it or what is left to complete it

## Approach

All these are optional depending on the size and context of the work being done.

* A high-level account of how the solution was achieved
* You might include some names of components/files for clarity, but is meant to be a general description
* Highlight the starting point for the review, like the highest level component or page
* Link to the automated test that proves the feature is working
* Provide a sequence or class diagram of the areas affected, with accurate names of the components and functions involved. This is optional unless you generated it with an agent or created one for the work (smart contract designs for instance).

## QA

* Provide the paths at which the UI have changed and instructions on how to navigate to the areas affected by the PR
* Explain how it was before and how these changes affect the UI/system, what should people notice after the changes have been introduced

## Key decisions

* Important decisions with ramifications on future work
* Tradeoffs
* Heads up for new reusable components

