### PR TITLE
chore: disable sync-upstream

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -18,9 +18,10 @@ on:
   # https://github.com/Labrys-Group/create-t3-turbo/actions/workflows/sync-upstream.yml
   # Click "Run workflow"
   workflow_dispatch: # Allow manual triggering
-  schedule:
-    # Run daily at 2 AM UTC
-    - cron: '0 2 * * *'
+  # Scheduled auto-sync disabled — uncomment to re-enable the daily run
+  # schedule:
+  #   # Run daily at 2 AM UTC
+  #   - cron: '0 2 * * *'
 
 # You can leverage Vercel Remote Caching with Turbo to speed up your builds
 env:


### PR DESCRIPTION
Hi,

Could you disable this workflow for now. It runs every morning and I get a notification in GitHub when it fails. I think its failing because my PAT no longer has access to the repo. Also the base repo doesn't look like its maintained anymore.

Thanks
